### PR TITLE
Downgrade in order to get blocks from peers

### DIFF
--- a/docker-compose/alastria-node-data/env/geth.common.sh
+++ b/docker-compose/alastria-node-data/env/geth.common.sh
@@ -35,7 +35,8 @@ GLOBAL_ARGS="--networkid $NETID \
 --targetgaslimit $TARGETGASLIMIT \
 --syncmode $SYNCMODE \
 --gcmode $GCMODE \
---vmodule $VMODULE "
+--vmodule $VMODULE \
+--nousb "
 
 # Any additional arguments
 LOCAL_ARGS=""

--- a/docker-compose/alastria-node-data/env/geth.node.general.sh
+++ b/docker-compose/alastria-node-data/env/geth.node.general.sh
@@ -4,7 +4,7 @@
 NODE_ARGS=" --rpc --rpcaddr 127.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul --rpcport 22000"
 
 # The Grafana server for pulling metrics. tcp/6060 should be opened
-METRICS=" --metrics --pprof --pprof.addr=0.0.0.0"
+# METRICS=" --metrics --pprof --pprof.addr=0.0.0.0"
 
 # Example - Enable WS connections
 # NODE_ARGS=${NODE_ARGS}" --ws --wsaddr 127.0.0.0 --wsport 22001 --wsorigins source.com"

--- a/docker-compose/alastria-node/Dockerfile
+++ b/docker-compose/alastria-node/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get -y install \
 
 RUN apt-get install -y golang
 
-ENV VER="v20.10.0"
+ENV VER="v21.1.0"
 
 WORKDIR /root
 RUN wget -O geth_${VER}_linux_amd64.tar.gz https://artifacts.consensys.net/public/go-quorum/raw/versions/${VER}/geth_${VER}_linux_amd64.tar.gz

--- a/docker-compose/alastria-node/Dockerfile
+++ b/docker-compose/alastria-node/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get -y install \
 
 RUN apt-get install -y golang
 
-ENV VER="v21.10.2"
+ENV VER="v20.10.0"
 
 WORKDIR /root
 RUN wget -O geth_${VER}_linux_amd64.tar.gz https://artifacts.consensys.net/public/go-quorum/raw/versions/${VER}/geth_${VER}_linux_amd64.tar.gz


### PR DESCRIPTION
GoQuorum 21.xx.xx doesn't recibe blocks using fast-sync mode.

Using fast-sync it's mandatoy for new nodes using Geth 1.9 - based nodes: full-sync fails as seen in https://github.com/ConsenSys/quorum/issues/1107