### PR TITLE
Add improved dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ ENV TARGETGASLIMIT="8000000"
 ENV VERBOSITY="3"
 ENV VMMODULE="consensus/istanbul/core/core.go=5"
 ENV LOCAL_ARGS=""
-ENV EXTERNAL_IP="1.2.3.4"
+ENV EXTERNAL_IP="127.0.0.1"
 ENV LOCAL_INTERFACE="0.0.0.0"
 # default args for a general node
 ENV NODE_ARGS="--http --http.api admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul --http.port 22000"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,34 @@
+FROM quorumengineering/quorum:21.10
+
+ENV NODE_BRANCH="main"
+ENV NODE_NAME="alastria-node"
+ENV NODE_TYPE="general"
+ENV NETID="83584648538"
+ENV P2P_PORT="21000"
+ENV ISTANBUL_REQUESTTIMEOUT="10000"
+ENV SYNCMODE="fast"
+ENV CACHE="4196"
+ENV GCMODE="full"
+ENV TARGETGASLIMIT="8000000"
+ENV VERBOSITY="3"
+ENV VMMODULE="consensus/istanbul/core/core.go=5"
+ENV LOCAL_ARGS=""
+ENV EXTERNAL_IP="1.2.3.4"
+ENV LOCAL_INTERFACE="0.0.0.0"
+# default args for a general node
+ENV NODE_ARGS="--http --http.api admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul --http.port 22000"
+ENV METRICS=" --metrics --pprof --pprof.addr=0.0.0.0"
+
+
+COPY ./entrypoint.sh /usr/local/bin/
+RUN ["chmod", "-R", "a+rwx", "/usr/local/bin"]
+
+RUN ["mkdir", "/opt/alastria"]
+RUN ["mkdir", "/opt/alastria/env"]
+RUN ["chmod", "-R", "a+rwx", "/opt/alastria"]
+
+# never let a container run as root
+USER 1001
+RUN ls -l /usr/local/bin
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,1 +1,21 @@
-# WIP · Procedure for `docker` installations
+# Dockerfile for building runtime-configurable images
+
+The docker file is based on the [quorumengineering/quorum](https://hub.docker.com/r/quorumengineering/quorum) base image, as provided by the origial maintainers [ConsenSys](https://github.com/ConsenSys/quorum/blob/master/README.md). It implements some sane defaults for running an alastria node, some docker best practices and improvements for running inside kubernetes clusters. Important features(in contrast to the image described at [docker-compose]()../docker-compose)) are:
+
+* does not run as root
+* enables runtime-configuration via env-vars, see [Dockerfile](./Dockerfile) for a full list
+* supports easier configuration of the external ip-address
+* follows the maintained base-image
+* reduces dependencies(f.e. no bash)
+
+## Build
+
+```shell
+    docker build . -t alastria-node
+```
+
+## Rum
+
+```shell
+    docker run -e EXTERNAL_IP=<MY_LOADBALANCER_IP> -e NODE_NAME="my-node" -e NODE_TYPE="general"  alastria-node
+```    

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+
+set -e
+
+echo "Starting the node..."
+
+# Create the data/geth directory if it does not exist yet
+# uses the opt-path to not collide with root users
+mkdir -p /opt/alastria/data/geth
+
+# Make sure we are in /root
+cd /opt
+
+# Geth arguments from the env vars
+GLOBAL_ARGS="--networkid $NETID \
+--identity $NODE_NAME \
+--permissioned \
+--cache $CACHE \
+--port $P2P_PORT \
+--istanbul.requesttimeout $ISTANBUL_REQUESTTIMEOUT \
+--verbosity $VERBOSITY \
+--emitcheckpoints \
+--targetgaslimit $TARGETGASLIMIT \
+--syncmode $SYNCMODE \
+--gcmode $GCMODE \
+--vmodule $VMODULE \
+--http.addr='$LOCAL_INTERFACE' \
+--ws.addr='$LOCAL_INTERFACE' \
+--nat extip:$EXTERNAL_IP \
+--nousb "
+
+# Generate the nodekey and enode_address if it is not already generated
+if [ ! -e /opt/alastria/data/INITIALIZED ]; then
+
+    echo "INFO [00-00|00:00:00.000|entrypoint.sh:${LINENO}] Generating nodekey and ENODE_ADDRESS"
+
+    # Download the genesis block from the Alastria node repository
+    echo "INFO [00-00|00:00:00.000|entrypoint.sh:${LINENO}] Generating genesis.json and initialize structure..."
+    
+    wget -q -O /opt/alastria/genesis.json https://raw.githubusercontent.com/alastria/alastria-node-quorum-directory/main/genesis.json
+    
+    echo "INFO [00-00|00:00:00.000|entrypoint.sh:${LINENO}] ... Storage initialized"
+    
+    # Initialize the Blockchain structure
+    echo "INFO [00-00|00:00:00.000|entrypoint.sh:${LINENO}] Initialize the Blockchain with the genesis block"
+    
+    /usr/local/bin/geth --datadir /opt/alastria/data/ init /opt/alastria/genesis.json
+    
+    echo "INFO [00-00|00:00:00.000|entrypoint.sh:${LINENO}] ... Blockchain initialized"
+    
+    # Signal that the initialization process has been performed
+    # Write the file INITIALIZED in the /root directory
+    echo "INITIALIZED" > /opt/alastria/data/INITIALIZED
+
+fi
+
+echo "INFO [00-00|00:00:00.000|entrypoint.sh:${LINENO}] Upgrading enodes list"
+
+TMPFILE=$(mktemp /tmp/updatePerm.XXXXXX)
+echo "INFO [00-00|00:00:00.000|entrypoint.sh:${LINENO}] Getting current nodes:"
+
+for i in boot-nodes.json validator-nodes.json regular-nodes.json ; do
+    wget -q -O /opt/alastria/env/${i} https://raw.githubusercontent.com/alastria/alastria-node-quorum-directory/${NODE_BRANCH}/data/${i}
+    ls -l /opt/alastria/env/
+    echo "INFO [00-00|00:00:00.000|entrypoint.sh:${LINENO}] Getting ${i} nodes..."
+done
+
+echo "INFO [00-00|00:00:00.000|entrypoint.sh:${LINENO}] ... nodes recibed"
+
+echo "INFO [00-00|00:00:00.000|entrypoint.sh:${LINENO}] Parsing correct databases"
+case ${NODE_TYPE} in
+    "bootnode")
+            cat /opt/alastria/env/boot-nodes.json /root/alastria/env/validator-nodes.json /opt/alastria/env/regular-nodes.json >> $TMPFILE
+    ;;
+    "validator")
+            cat /opt/alastria/env/boot-nodes.json /opt/alastria/env/validator-nodes.json >> $TMPFILE
+    ;;
+    "general")
+            cat /opt/alastria/env/boot-nodes.json >> $TMPFILE
+    ;;
+    *)
+            echo "ERROR: nodetype not recognized"
+            exit 1
+    ;;
+esac
+
+sed -e '1s/^/[\n/' -i $TMPFILE
+sed -e '$s/,$/\n]/' -i $TMPFILE
+
+cat $TMPFILE > /opt/alastria/data/static-nodes.json
+cat $TMPFILE > /opt/alastria/data/permissioned-nodes.json
+
+# Start the geth node
+export PRIVATE_CONFIG="ignore"
+
+# Start geth
+
+echo "--datadir /opt/alastria/data ${GLOBAL_ARGS} ${METRICS} ${NODE_ARGS} ${LOCAL_ARGS}"
+geth --datadir /opt/alastria/data ${GLOBAL_ARGS} ${METRICS} ${NODE_ARGS} ${LOCAL_ARGS}
+echo "nect"
+
+geth --exec "admin.nodeInfo.enode" attach /opt/alastria/data/geth.ipc
+
+echo "INFO [00-00|00:00:00.000|entrypoint.sh:${LINENO}] ... ENODE_ADDRESS generated."


### PR DESCRIPTION
The docker-setup described in the compose folder had a couple of drawbacks, that the new file tries to solve:
- runtime configuration via env-vars
- smaller base image, following the original providers
- better support for running in restricted cloud enviornments(like k8s, openshift) by running as non-root and easier configuration for ip-addresse configuration