### PR TITLE
Add Prometheus and Netstats metrics by default

### DIFF
--- a/docker-compose/alastria-node-data/env/geth.node.general.sh
+++ b/docker-compose/alastria-node-data/env/geth.node.general.sh
@@ -4,7 +4,7 @@
 NODE_ARGS=" --rpc --rpcaddr 127.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul --rpcport 22000"
 
 # The Grafana server for pulling metrics. tcp/6060 should be opened
-# METRICS=" --metrics --pprof --pprof.addr=0.0.0.0"
+METRICS=" --metrics --pprof --pprof.addr=0.0.0.0 --ethstats $NODE_NAME:bb98a0b6442386d0cdf8a31b267892c1@netstats.telsius.alastria.io:80"
 
 # Example - Enable WS connections
 # NODE_ARGS=${NODE_ARGS}" --ws --wsaddr 127.0.0.0 --wsport 22001 --wsorigins source.com"

--- a/docker-compose/alastria-node-data/env/geth.node.general.sh
+++ b/docker-compose/alastria-node-data/env/geth.node.general.sh
@@ -4,7 +4,7 @@
 NODE_ARGS=" --rpc --rpcaddr 127.0.0.0 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul --rpcport 22000"
 
 # The Grafana server for pulling metrics. tcp/6060 should be opened
-METRICS=" --metrics --pprof --pprof.addr=0.0.0.0 --ethstats $NODE_NAME:bb98a0b6442386d0cdf8a31b267892c1@netstats.telsius.alastria.io:80"
+METRICS=" --ethstats $NODE_NAME:bb98a0b6442386d0cdf8a31b267892c1@netstats.telsius.alastria.io:80"
 
 # Example - Enable WS connections
 # NODE_ARGS=${NODE_ARGS}" --ws --wsaddr 127.0.0.0 --wsport 22001 --wsorigins source.com"


### PR DESCRIPTION
Adición de métricas para Prometheus/Grafana y Ethstats por defecto en los nodos regulares.