### PR TITLE
Automatic check4updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,14 @@ With this, your node should be running fine and on the desired GoQuorum version.
 
 # Adding automatic checking for updates in node lists
 
-If your installation was done with docker-compose everything is set up and there's nothing else to do :tada:
+If your installation was done with docker-compose everything is set up in the container and there's nothing else to do :tada:
+
+However, if your installation was done prior to April 2022, ensure you have the more up-to-date code running in your machine following these steps:
+
+* Stop the node with `docker-compose down`
+* Pull the more current code from the repository with `git pull`
+* Edit the `docker-compose.yml` file if you need a custom configuration in `volumes` and `ports` sections
+* Start the container forcing the image to be build again with `docker-compose up --build -d`
 
 For installations done with older methods ([alastria-node](https://github.com/alastria/alastria-node) repository), please, follow the next steps.
 

--- a/README.md
+++ b/README.md
@@ -358,8 +358,9 @@ If your installation was done with docker-compose everything is set up in the co
 However, if your installation was done prior to June 2022, ensure you have the more up-to-date code running in your machine following these steps:
 
 * Stop the node with `docker-compose down`
+* Do a backup of the `docker-compose.yml` and the `.env` files to make sure you don't lose any configuration
 * Pull the more current code from the repository with `git pull`
-* Edit the `docker-compose.yml` file if you need a custom configuration in `volumes` and `ports` sections
+* Edit the `docker-compose.yml` and the `.env` files if you need a custom configuration in `volumes` and `ports` sections, and to set the type and the name of your node
 * Start the container forcing the image to be build again with `docker-compose up --build -d`
 
 # Other Resources

--- a/README.md
+++ b/README.md
@@ -355,34 +355,12 @@ With this, your node should be running fine and on the desired GoQuorum version.
 
 If your installation was done with docker-compose everything is set up in the container and there's nothing else to do :tada:
 
-However, if your installation was done prior to April 2022, ensure you have the more up-to-date code running in your machine following these steps:
+However, if your installation was done prior to June 2022, ensure you have the more up-to-date code running in your machine following these steps:
 
 * Stop the node with `docker-compose down`
 * Pull the more current code from the repository with `git pull`
 * Edit the `docker-compose.yml` file if you need a custom configuration in `volumes` and `ports` sections
 * Start the container forcing the image to be build again with `docker-compose up --build -d`
-
-For installations done with older methods ([alastria-node](https://github.com/alastria/alastria-node) repository), please, follow the next steps.
-
-* First of all update your updatePerm.sh script:
-```console
-$ wget -q -O ~/alastria-node/scripts/updatePerm.sh https://raw.githubusercontent.com/alastria/alastria-node-quorum/main/scripts/updatePerm.sh
-```
-
-* Download the script that will restart the node if there are changes in the lists of nodes:
-```console
-$ wget -q -O ~/alastria-node/scripts/checkForUpdates.sh https://raw.githubusercontent.com/alastria/alastria-node-quorum/main/scripts/checkForUpdates.sh
-```
-
-* For last, schedule the execution of this script with crontab:
-```console
-$ crontab -l > ~/crontab.file
-$ echo "`date +"%M"` * * * * ~/alastria-node/scripts/checkForUpdates.sh" >> ~/crontab.file
-$ crontab ~/crontab.file
-```
-Ensure that cron daemon is running.
-
-With this your machine will check every hour if there are any changes in the nodes of the network, and if so, it will restart the node to make it aware of the changes and update its connections accordingly.
 
 # Other Resources
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,32 @@ To upgrade your node's GoQuorum version you must update the GoQuorum binaries wi
 
 With this, your node should be running fine and on the desired GoQuorum version.
 
+# Adding automatic checking for updates in node lists
+
+If your installation was done with docker-compose everything is set up and there's nothing else to do :tada:
+
+For installations done with older methods ([alastria-node](https://github.com/alastria/alastria-node) repository), please, follow the next steps.
+
+* First of all update your updatePerm.sh script:
+```console
+$ wget -q -O ~/alastria-node/scripts/updatePerm.sh https://raw.githubusercontent.com/alastria/alastria-node-quorum/main/scripts/updatePerm.sh
+```
+
+* Download the script that will restart the node if there are changes in the lists of nodes:
+```console
+$ wget -q -O ~/alastria-node/scripts/checkForUpdates.sh https://raw.githubusercontent.com/alastria/alastria-node-quorum/main/scripts/checkForUpdates.sh
+```
+
+* For last, schedule the execution of this script with crontab:
+```console
+$ crontab -l > ~/crontab.file
+$ echo "`date +"%M"` * * * * ~/alastria-node/scripts/checkForUpdates.sh" >> ~/crontab.file
+$ crontab ~/crontab.file
+```
+Ensure that cron daemon is running.
+
+With this your machine will check every hour if there are any changes in the nodes of the network, and if so, it will restart the node to make it aware of the changes and update its connections accordingly.
+
 # Other Resources
 
 + [Wiki](https://github.com/alastria/alastria-node/wiki)

--- a/docker-compose/alastria-node/Dockerfile
+++ b/docker-compose/alastria-node/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update
 RUN apt-get -y install \
         wget \
         nano \
-        vim \       
+        vim \ 
+        cron \      
     && apt-get autoremove \
     && apt-get clean
 
@@ -19,8 +20,8 @@ WORKDIR /root
 RUN wget -O geth_${VER}_linux_amd64.tar.gz https://artifacts.consensys.net/public/go-quorum/raw/versions/${VER}/geth_${VER}_linux_amd64.tar.gz
 RUN tar zxvf geth_${VER}_linux_amd64.tar.gz -C /usr/local/bin
 
-COPY entrypoint.sh /usr/local/bin/
-RUN ["chmod", "+x", "/usr/local/bin/entrypoint.sh"]
+COPY entrypoint.sh checkForUpdates.sh /usr/local/bin/
+RUN ["chmod", "+x", "/usr/local/bin/entrypoint.sh", "/usr/local/bin/checkForUpdates.sh"]
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
 CMD ["start"]

--- a/docker-compose/alastria-node/checkForUpdates.sh
+++ b/docker-compose/alastria-node/checkForUpdates.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+github_md5sum_regular=$(wget https://raw.githubusercontent.com/alastria/alastria-node-quorum-directory/${NODE_BRANCH}/data/regular-nodes.json --quiet -O - | md5sum)
+local_md5sum_regular=$(cat /root/alastria/env/regular-nodes.json | md5sum)
+
+github_md5sum_boot=$(wget https://raw.githubusercontent.com/alastria/alastria-node-quorum-directory/${NODE_BRANCH}/data/boot-nodes.json --quiet -O - | md5sum)
+local_md5sum_boot=$(cat /root/alastria/env/boot-nodes.json | md5sum)
+
+github_md5sum_validator=$(wget https://raw.githubusercontent.com/alastria/alastria-node-quorum-directory/${NODE_BRANCH}/data/validator-nodes.json --quiet -O - | md5sum)
+local_md5sum_validator=$(cat /root/alastria/env/validator-nodes.json | md5sum)
+
+case ${NODE_TYPE} in
+    "bootnode")
+        if [ "$github_md5sum_boot" != "$local_md5sum_boot" ] || [ "$github_md5sum_validator" != "$local_md5sum_validator" ] || [ "$github_md5sum_regular" != "$local_md5sum_regular" ]; then
+            pkill -f geth
+        fi
+    ;;
+    "validator")
+        if [ "$github_md5sum_boot" != "$local_md5sum_boot" ] || [ "$github_md5sum_validator" != "$local_md5sum_validator" ]; then
+            pkill -f geth
+        fi
+    ;;
+    "general")
+        if [ "$github_md5sum_boot" != "$local_md5sum_boot" ]; then
+            pkill -f geth
+        fi
+    ;;
+    *)
+        echo "ERROR: nodetype not recognized"
+        exit 1
+    ;;
+esac

--- a/docker-compose/alastria-node/entrypoint.sh
+++ b/docker-compose/alastria-node/entrypoint.sh
@@ -75,6 +75,11 @@ if [ "$1" = 'start' ]; then
 
     cat $TMPFILE > /root/alastria/data/static-nodes.json
     cat $TMPFILE > /root/alastria/data/permissioned-nodes.json
+    rm -f $TMPFILE
+    
+    # Set the cron task to update peers every hour (if there are any changes)
+    echo "`date +"%M"` * * * * NODE_TYPE=${NODE_TYPE} NODE_BRANCH=${NODE_BRANCH} /usr/local/bin/checkForUpdates.sh" > /tmp/crontab.file
+    crontab /tmp/crontab.file && cron
 
     # Set the environment variables for the geth arguments from a file
     source /root/alastria/env/geth.common.sh

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -4,6 +4,7 @@ version: "3.7"
 services:
   alastria-node:
     build: ./alastria-node
+    restart: unless-stopped
     container_name: ${NODE_NAME}
     volumes:
       - "./alastria-node-data:/root/alastria"

--- a/scripts/checkForUpdates.sh
+++ b/scripts/checkForUpdates.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+github_md5sum_regular=$(wget https://raw.githubusercontent.com/alastria/alastria-node-quorum-directory/${NODE_BRANCH}/data/regular-nodes.json --quiet -O - | md5sum)
+local_md5sum_regular=$(cat /root/alastria/env/regular-nodes.json | md5sum)
+
+github_md5sum_boot=$(wget https://raw.githubusercontent.com/alastria/alastria-node-quorum-directory/${NODE_BRANCH}/data/boot-nodes.json --quiet -O - | md5sum)
+local_md5sum_boot=$(cat /root/alastria/env/boot-nodes.json | md5sum)
+
+github_md5sum_validator=$(wget https://raw.githubusercontent.com/alastria/alastria-node-quorum-directory/${NODE_BRANCH}/data/validator-nodes.json --quiet -O - | md5sum)
+local_md5sum_validator=$(cat /root/alastria/env/validator-nodes.json | md5sum)
+
+case ${NODE_TYPE} in
+    "bootnode")
+        if [ "$github_md5sum_boot" != "$local_md5sum_boot" ] || [ "$github_md5sum_validator" != "$local_md5sum_validator" ] || [ "$github_md5sum_regular" != "$local_md5sum_regular" ]; then
+            ~/alastria-node/scripts/restart.sh auto
+        fi
+    ;;
+    "validator")
+        if [ "$github_md5sum_boot" != "$local_md5sum_boot" ] || [ "$github_md5sum_validator" != "$local_md5sum_validator" ]; then
+            ~/alastria-node/scripts/restart.sh auto
+        fi
+    ;;
+    "general")
+        if [ "$github_md5sum_boot" != "$local_md5sum_boot" ]; then
+            ~/alastria-node/scripts/restart.sh auto
+        fi
+    ;;
+    *)
+        echo "ERROR: nodetype not recognized"
+        exit 1
+    ;;
+esac


### PR DESCRIPTION
We use the checkForUpdates.sh scripts to compare the md5 checksum of the data files in alastria-node-quorum-directory with those currently in the node. If any changes are detected the node is updated and restarted:
- In the case of docker-compose installation, the script kills the geth process, making the container to end. Therefore we configure the container to restart in case of failure to automatically bringing it up after the geth process is terminated. That way the static-nodes.json and permissioned-nodes.json files are updated.
- In the case of older type of installation, the script calls the restart.sh script, which should make the node to fully restart, updating the  static-nodes.json and permissioned-nodes.json files.

The cron job is scheduled like "_m_ * * * *", where _m_ is the exact minute when the job is scheduled. This way we introduce some factor of randomness, so the nodes do not restart all at the same moment.