### PR TITLE
Update geth options

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,12 +307,12 @@ The validator nodes must focus on operating the consensus protocol, integrating 
 ### geth args for regular/general Nodes
 
 ```console
-NODE_ARGS=' --rpc --rpcaddr 0.0.0.0 --rpcport 22000 --rpccorsdomain "*" --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul'
+NODE_ARGS=' --rpc --rpcaddr 0.0.0.0 --rpcport 22000 --rpccorsdomain "*" --rpcvhosts "*" --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul'
 ```
 
 Also WebSockets connection is allowed:
 ```console
-NODE_ARGS=" --ws --wsaddr 0.0.0.0 --wsport 22001 --wsorigins source.com"
+NODE_ARGS=${NODE_ARGS}' --ws --wsaddr 0.0.0.0 --wsport 22001 --wsorigins "*" --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul'
 ```
 
 > NOTE: use of [GraphQL](https://docs.goquorum.consensys.net/en/stable/HowTo/Use/graphql/) will be available soon.
@@ -362,7 +362,7 @@ $ geth attach alastria/data/geth.ipc
 ## geth args for validator nodes
 
 ```console
-NODE_ARGS=" --maxpeers 32 --mine --minerthreads $(grep -c "processor" /proc/cpuinfo)"
+NODE_ARGS=" --maxpeers 32 --mine --miner.gastarget 8000000 --miner.gaslimit 10000000 --minerthreads $(grep -c "processor" /proc/cpuinfo) --miner.extradata $NODE_NAME"
 ```
 
 # Other Resources
@@ -455,13 +455,13 @@ module.exports = {
 
 ## Changelog 
 
-### Monitoring 2022/02/14
+### Monitoring 2022/06/16
 
 Alastria T Network dashboard is at https://alastria-netstats2.planisys.net:8443/login , user alastria, pass alastria
 
 In order for your Node to be listed here please run geth with following options:
 
-* --metrics --pprof --pprof.addr=0.0.0.0
+* --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0
 
 and open port 6060 to IP address 185.180.8.152
 

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -8,4 +8,3 @@
 NODE_TYPE=general
 NODE_NAME=REG_ExampleOrg_T_2_8_00
 NODE_BRANCH=main
-METRICS="--metrics --metrics.expensive --pprof --pprof.addr=0.0.0.0"

--- a/docker-compose/alastria-node-data/env/geth.common.sh
+++ b/docker-compose/alastria-node-data/env/geth.common.sh
@@ -12,8 +12,6 @@ SYNCMODE="fast"
 CACHE="4196"
 # Blockchain garbage collection mode
 GCMODE="full"
-# Target gas limit sets the artificial target gas floor for the blocks to mine
-TARGETGASLIMIT="8000000"
 # General logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail
 VERBOSITY="3"
 # Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=5,p2p=4)
@@ -32,7 +30,6 @@ GLOBAL_ARGS="--networkid $NETID \
 --istanbul.requesttimeout $ISTANBUL_REQUESTTIMEOUT \
 --verbosity $VERBOSITY \
 --emitcheckpoints \
---targetgaslimit $TARGETGASLIMIT \
 --syncmode $SYNCMODE \
 --gcmode $GCMODE \
 --vmodule $VMODULE \

--- a/docker-compose/alastria-node-data/env/geth.node.bootnode.sh
+++ b/docker-compose/alastria-node-data/env/geth.node.bootnode.sh
@@ -1,9 +1,5 @@
 # general ARGS for bootnode
 NODE_ARGS="--maxpeers 256"
 
-# The Ethstats server where to send the info
-METRICS=" --ethstats $NODE_NAME:1bdf9149555dbb77ec68aadce67897cf@netstats.core-redt.alastria.io"
-
-# The Grafana server for pulling metrics. tcp/6060 should be opened
-# Uncomment the following line only in GoQuorum versions >= v21.10.0
-# METRICS=" --metrics --pprof --pprof.addr=0.0.0.0"
+# For pulling metrics from Prometheus/Grafana server. tcp/6060 should be opened
+METRICS="--metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0"

--- a/docker-compose/alastria-node-data/env/geth.node.general.sh
+++ b/docker-compose/alastria-node-data/env/geth.node.general.sh
@@ -1,10 +1,10 @@
 # general ARGS for general/regular node
 
-# Example - Enable RPC connections
-NODE_ARGS=' --rpc --rpcaddr 0.0.0.0 --rpcport 22000 --rpccorsdomain "*" --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul'
+# Enable RPC connections
+NODE_ARGS=' --rpc --rpcaddr 0.0.0.0 --rpcport 22000 --rpccorsdomain "*" --rpcvhosts "*" --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul'
 
 # The Ethstats server where to send the info
 METRICS=" --ethstats $NODE_NAME:bb98a0b6442386d0cdf8a31b267892c1@netstats.telsius.alastria.io:80"
 
-# Example - Enable WS connections
-# NODE_ARGS=${NODE_ARGS}" --ws --wsaddr 0.0.0.0 --wsport 22001 --wsorigins source.com"
+# Enable WS connections
+NODE_ARGS=${NODE_ARGS}' --ws --wsaddr 0.0.0.0 --wsport 22001 --wsorigins "*" --wsapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul'

--- a/docker-compose/alastria-node-data/env/geth.node.validator.sh
+++ b/docker-compose/alastria-node-data/env/geth.node.validator.sh
@@ -1,9 +1,5 @@
 # validator ARGS for validator node
-NODE_ARGS=" --maxpeers 32 --mine --minerthreads $(grep -c "processor" /proc/cpuinfo)"
+NODE_ARGS=" --maxpeers 32 --mine --miner.gastarget 8000000 --miner.gaslimit 10000000 --minerthreads $(grep -c "processor" /proc/cpuinfo) --miner.extradata $NODE_NAME"
 
-# The Ethstats server where to send the info
-METRICS=" --ethstats $NODE_NAME:1bdf9149555dbb77ec68aadce67897cf@netstats.core-redt.alastria.io"
-
-# The Grafana server for pulling metrics. tcp/6060 should be opened
-# Uncomment the following line only in GoQuorum versions >= v21.10.0
-# METRICS=" --metrics --pprof --pprof.addr=0.0.0.0"
+# For pulling metrics from Prometheus/Grafana server. tcp/6060 should be opened
+METRICS="--metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0"

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "21000:21000/tcp"
       - "21000:21000/udp"
       - "6060:6060/tcp"
-# Enable connection for dApps. Only for Regular/General
+# Enable connection for dApps. Only for Regular/General nodes
 #
 # To be used from RCP/JSON:
 #     - "22000:22000/tcp"
@@ -24,4 +24,3 @@ services:
       - NODE_TYPE=${NODE_TYPE}
       - NODE_NAME=${NODE_NAME}
       - NODE_BRANCH=${NODE_BRANCH}
-      - METRICS=${METRICS}


### PR DESCRIPTION
Adaptación y actualización de las opciones de geth para la versión 21.1.0 de GoQuorum:

- Completamos las opciones para conexiones HTTP/WS en los nodos regulares
- Establecemos miner.gastarget (8M gas) y miner.gaslimit (10M gas) en los nodos validadores
- Añadimos el nombre del nodo en el bloque generado (valor extradata/vanity del bloque) con miner.extradata
- Añadimos opciones para monitorización con prometheus/grafana en validadores y bootnodes
- Eliminamos opción targetgaslimit (mal utilizada y deprecada)
- Quitamos las opciones para las métricas de los archivos de configuración incorrectos
- Actualizamos readme