### PR TITLE
Avoid conflicts in shared nodes

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -2,7 +2,7 @@
 
 version: "3.7"
 services:
-  alastria-node:
+  alastria-node-quorum:
     build: ./alastria-node
     restart: unless-stopped
     container_name: ${NODE_NAME}


### PR DESCRIPTION
When using the default docker-compose file, there are a conflict in the name, and the container name is overwritten